### PR TITLE
Add Composum AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,6 +757,7 @@ In essence, Generative AI is about feeding an AI system vast amounts of data, tr
 * [Taskade](https://taskade.com/): Taskade is an AI outliner and mind map generator for teams with built-in AI chat
 * [AI Story Generator](https://www.aistorygenerator.org): Free and fast online AI-powered story generator that writes short stories for you
 * [AI Story Generate](https://aistorygenerate.com): Generate stories using LLM with custom emotion, genre, and word count.
+* [Composum AI](https://github.com/ist-dresden/composum-AI) Plugin for CMS Adobe Experience Manager (AEM) or Composum Pages helping the editor to create / edit / translate texts
 
 ## Research AI Tools
 


### PR DESCRIPTION
The Composum AI provides extensions for both the Adobe Experience Manager (AEM) or the free Composum Pages CMS that tightly integrates OpenAI ChatGPT capabilities into the CMS editor to allow content authors to analyze and discuss 
content with ChatGPT, suggest completions, translate, transform texts, and more. It also allows free prompting of 
ChatGPT.

Github: https://github.com/ist-dresden/composum-AI
Site: https://ist-dresden.github.io/composum-AI/
Quick Demo: https://www.youtube.com/watch?v=lSdKlwIDPkE / https://www.youtube.com/watch?v=96gv-F4zX_o

Language: Java
Licence: MIT licence
