### PR TITLE
Add Co-Developer GPT engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1084,6 +1084,7 @@ In essence, Generative AI is about feeding an AI system vast amounts of data, tr
 * [The Impact of AI on Developer Productivity: Evidence from GitHub Copilot | arxiv](https://arxiv.org/abs/2302.06590) 
 * [openai/openai-cookbook](https://github.com/openai/openai-cookbook): Examples and guides for using the OpenAI API
 * [Reduce costs when prompting using GPT](https://www.codium.ai/blog/reduce-your-costs-by-30-when-using-gpt-3-for-python-code/)
+* [Co-Developer GPT engine](https://github.com/stoerr/CoDeveloperGPTengine) - local r/w file access and execute actions from an OpenAI GPT 
 
 # Multimodal
 


### PR DESCRIPTION
* [Co-Developer GPT engine](https://github.com/stoerr/CoDeveloperGPTengine) - provides local r/w file access from ChatGPT chat as GPT actions or ChatGPT plugin, incl. execution of configured actions on your own machine.

https://github.com/taishi-i/awesome-ChatGPT-repositories/pull/44

The free Co-Developer GPT engine serves in OpenAI GPTs and as ChatGPT plugin to give ChatGPT in the chat the ability to modify the files in the directory it is started in, and thus makes it possible to discuss code without copying and pasting it there, and to let ChatGPT write code / modify, even run build actions fixing problems until they work.

https://CoDeveloperGPTengine.stoerr.net/
https://github.com/stoerr/CoDeveloperGPTengine
https://www.youtube.com/watch?v=ubBhv2PUSEs

Language: Java
Licence: Apache-2.0