### PR TITLE
Add GPT Mobile Android app project

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ In essence, Generative AI is about feeding an AI system vast amounts of data, tr
 * [Yona.ai](https://yona.ai): Create deeply personalized AI chatbots from your own conversations, your stories, your data. You can harness the power of your chat history to build an AI companion for a nostalgic trip down memory lane, whimsical fantasies, or any other unique purpose.
 * [Voicesphere](https://www.voicesphere.co/): Chat with your documents to get intelligent, context specific answers.
 * [Tune AI](https://chat.tune.app/): AI chat app powered by open source models
+* [GPT Mobile](https://github.com/Taewan-P/gpt_mobile) GPT Mobile is an Android app that can chat with multiple LLMs at once! Currently supports ChatGPT, Anthropic Claude, and Google Gemini.
 
 # Text
 


### PR DESCRIPTION
GPT Mobile is an Android app that can chat with multiple LLMs at once! It currently supports ChatGPT, Anthropic Claude, and Google Gemini. When starting a chat, you can choose which platforms to get answers from. Also, the chat history is only saved locally and only sends to official API servers while chatting.

Currently planning to support multi-modal features in chat! 

It would be appreciated if you have a look at the project. Thanks

GitHub: https://github.com/Taewan-P/gpt_mobile