### PR TITLE
Add HelloGen to Video and Animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1248,6 +1248,7 @@ In essence, Generative AI is about feeding an AI system vast amounts of data, tr
 
 # Video and Animation
 
+* [HelloGen](https://hellogen.ai/): one studio over many image and video models, where you describe the shot in plain language and an assistant chooses the model and prices the render before it runs
 * [FramePack](https://www.framepack.video/): next-frame prediction neural network structure that generates videos progressively
 * [Keyla.AI](https://keyla.ai/): Create video ads in minutes
 * [Melies](https://melies.co/): All-in-one AI filmmaking software


### PR DESCRIPTION
Adding [HelloGen](https://hellogen.ai/) to the **Video and Animation** section.

**Entry:**
`* [HelloGen](https://hellogen.ai/): AI image and video generator that picks a model for your request and quotes the price before rendering, with unlimited watermark-free images on the free tier`

**What it is:** a hosted studio that runs several image and video models (Seedream, Nano Banana, GPT Image 2, Veo, Kling, Seedance) behind one assistant. You describe the job in plain language, the assistant picks a model and shows the price before anything renders, and failed generations aren't charged. Images are unlimited and watermark-free on the free tier, with a commercial license on outputs.

Placed at the top of the section per the repo's reverse-chronological ordering, using the existing `* [Name](url): description` format. One line, no other changes.