### PR TITLE
Add Kavel

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ In essence, Generative AI is about feeding an AI system vast amounts of data, tr
 * [GPT Mobile](https://github.com/Taewan-P/gpt_mobile) GPT Mobile is an Android app that can chat with multiple LLMs at once! Currently supports ChatGPT, Anthropic Claude, and Google Gemini.
 * [PageGen](https://pagegen.ai) - An AI Page Generator with Claude AI, React and Shadcn UI. Generate web pages from text, screenshot and templates with one click.
 * [PerchanceStory](https://perchancestory.com/): PerchanceStory is an AI-based interactive story generator, which generates ever-changing story endings with endless possibilities based on simple user-provided input. 
-- [Kavel](https://www.kavel.ai/) - AI image and video studio with a per-edit page for each job — hairstyle, outfit, expression, background — and a free tier that runs without an account.
+* [Kavel](https://www.kavel.ai/): AI image and video studio with a per-edit page for each job — hairstyle, outfit, expression, background — and a free tier that runs without an account
 
 # Code and Programming
 

--- a/README.md
+++ b/README.md
@@ -484,6 +484,7 @@ In essence, Generative AI is about feeding an AI system vast amounts of data, tr
 * [GPT Mobile](https://github.com/Taewan-P/gpt_mobile) GPT Mobile is an Android app that can chat with multiple LLMs at once! Currently supports ChatGPT, Anthropic Claude, and Google Gemini.
 * [PageGen](https://pagegen.ai) - An AI Page Generator with Claude AI, React and Shadcn UI. Generate web pages from text, screenshot and templates with one click.
 * [PerchanceStory](https://perchancestory.com/): PerchanceStory is an AI-based interactive story generator, which generates ever-changing story endings with endless possibilities based on simple user-provided input. 
+- [Kavel](https://www.kavel.ai/) - AI image and video studio with a per-edit page for each job — hairstyle, outfit, expression, background — and a free tier that runs without an account.
 
 # Code and Programming
 


### PR DESCRIPTION
Adds [Kavel](https://www.kavel.ai/) under **Online Tools and Applications**.

An AI image and video studio. What makes it different from the other entries in this section is the shape rather than the model: instead of one prompt box, it keeps a separate page per job — hairstyle, outfit swap, expression, background, aging — each preloaded with a prompt that works for that edit, which is the part people usually have to discover by trial.

There is a free tier that runs without an account, so the link is testable without signing up.